### PR TITLE
csv: add additional csv builder settings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,8 @@ pub use json_formats::JsonNewLineStreamFormat;
 #[cfg(feature = "csv")]
 mod csv_format;
 #[cfg(feature = "csv")]
+pub use csv::{QuoteStyle, Terminator};
+#[cfg(feature = "csv")]
 pub use csv_format::CsvStreamFormat;
 
 #[cfg(feature = "text")]


### PR DESCRIPTION
Hey,

Thank you for this crate, it came in handy!

My use case requires mingling with `QuoteStyle::Always` setting and `flexible` which are not accessible via the current builder. Adding all settings supported by `csv` crate, I have left the original function `new(` unchanged, so it does not become a breaking change. 