### PR TITLE
fix: the default behaviour is not aligned with the docs

### DIFF
--- a/src/csv_format.rs
+++ b/src/csv_format.rs
@@ -156,10 +156,7 @@ impl<'a> StreamBodyAs<'a> {
         T: Serialize + Send + Sync + 'static,
         S: Stream<Item = T> + 'a + Send,
     {
-        Self::new(
-            CsvStreamFormat::new(false, b','),
-            stream.map(Ok::<T, axum::Error>),
-        )
+        Self::new(CsvStreamFormat::default(), stream.map(Ok::<T, axum::Error>))
     }
 
     pub fn csv_with_errors<S, T, E>(stream: S) -> Self


### PR DESCRIPTION
AI disclaimer: I did not use AI to find or fix this. I just stumbled on a different behavior while using your library in my project.

Thanks for project.

----

In the docs, there is the following snippet:

```
//!     StreamBodyAs::csv(my_source_stream())
//!     // Which is the same as:
//!     // StreamBodyWith::new(CsvStreamFormat::new(
//!     //    true, // with_header
//!     //    b',' // CSV delimiter
//!     //), my_source_stream())
```

Which is incorrect given the current implementation. My proposal is to use the `default` implementation for the `CsvStreamFormat` which aligns with the docs.